### PR TITLE
Fix for diagonal sequence

### DIFF
--- a/Services/MatchingSequenceChecker.cs
+++ b/Services/MatchingSequenceChecker.cs
@@ -67,7 +67,9 @@ namespace SimplifiedSlotMachine.Services
             // Check for diagonal (\) matching sequences
             for (int i = 0; i <= rows; i++)
             {
-                var currentDiagonalLength = maxDiagonalLength - i;
+                var lengthAdjustment = i > 0 && rows > columns ? rows - columns : 0;
+
+                var currentDiagonalLength = maxDiagonalLength - (i - lengthAdjustment);
 
                 if (currentDiagonalLength < matchingSymbols)
                 {

--- a/Tests/MatchingSequenceCheckerTests.cs
+++ b/Tests/MatchingSequenceCheckerTests.cs
@@ -1,8 +1,8 @@
 ﻿using NUnit.Framework;
 using SimplifiedSlotMachine.Enums;
 using SimplifiedSlotMachine.Models;
-using SimplifiedSlotMachine.Services.Interfaces;
 using SimplifiedSlotMachine.Services;
+using SimplifiedSlotMachine.Services.Interfaces;
 
 [TestFixture]
 public class MatchingSequenceCheckerTests


### PR DESCRIPTION
Fix for diagonal sequence matching failing to match when the rows are greater than the columns